### PR TITLE
fix: enhance TestimonialCard

### DIFF
--- a/src/components/cards/TestimonialCard.tsx
+++ b/src/components/cards/TestimonialCard.tsx
@@ -1,11 +1,13 @@
 "use client";
-
+import { useEffect, useState } from "react";
 import Image from "next/image";
-import Heading from "../common/Heading";
-import Paragraph from "../common/Paragraph";
-import { StarCircle } from "../icons/Star";
+
 import clsx from "clsx";
-import { UserImage } from "../dashboard/UserImage";
+
+import Heading from "@/components/common/Heading";
+import Paragraph from "@/components/common/Paragraph";
+import { StarCircle } from "@/components/icons/Star";
+import { UserImage } from "@/components/dashboard/UserImage";
 
 type Props = {
   userImageUrl?: string;
@@ -24,15 +26,37 @@ function TestimonialCard({
   testimonial,
   className = "",
 }: Props) {
+  const [expandText, setExpandText] = useState(false);
+
+  useEffect(() => {
+    const closeText = (e: MouseEvent) => {
+      if (!(e.target instanceof HTMLElement)) return;
+      const target = e.target as HTMLElement;
+      if (
+        !target.closest(`.testimonial-card-${userName.replace(" ", "-")}`) &&
+        !target.closest(`.testimonial-card-text-${userName.replace(" ", "-")}`)
+      ) {
+        setExpandText(false);
+      }
+    };
+
+    // Close the text when clicking outside
+    document.addEventListener("click", closeText);
+    // Cleanup the event listener on component unmount
+    return () => {
+      document.removeEventListener("click", closeText);
+    };
+  }, []);
   return (
     <div
       className={clsx(
-        "relative flex rounded-2xl bg-bg text-surface overflow-visible w-full max-w-[440px]",
+        "relative flex rounded-2xl bg-bg text-surface overflow-visible w-full max-w-[460px]",
+        `testimonial-card-${userName.replace(" ", "-")}`,
         className
       )}
     >
       {/* content */}
-      <div className="relative z-20 flex h-full w-full max-w-[440px] sm:min-h-[240px] bg-bg p-3 rounded-2xl ">
+      <div className="relative z-20 flex h-full w-full sm:min-h-[240px] bg-bg p-3 rounded-2xl overflow-hidden">
         {/* bg */}
         <div className="absolute z-10 left-0 top-0 bottom-0">
           <Image
@@ -47,7 +71,12 @@ function TestimonialCard({
         <div className="z-20 max-w-[120px] sm:max-w-none flex flex-col justify-between items-center py-3">
           {/* image */}
           <div className="w-16 sm:w-24 h-16 sm:h-24 rounded-full overflow-hidden flex items-center justify-center">
-            <UserImage avatar={userImageUrl} username={userName} size="md" />
+            <UserImage
+              avatar={userImageUrl}
+              username={userName}
+              size="md"
+              className="text-bg/75 bg-surface/90"
+            />
           </div>
 
           {/* info */}
@@ -65,7 +94,12 @@ function TestimonialCard({
         </div>
 
         {/* review */}
-        <div className="z-20 flex flex-col gap-3 justify-center flex-1">
+        <div
+          className={`testimonial-card-text-${userName.replace(
+            " ",
+            "-"
+          )} z-20 flex flex-col gap-3 justify-center flex-1`}
+        >
           {/* stars */}
           <div className="flex gap-2">
             {Array.from({ length: 5 }, (_, i) => (
@@ -78,9 +112,32 @@ function TestimonialCard({
             ))}
           </div>
           {/* testimonial */}
-          <Paragraph size="sm" className="max-w-[32ch]">
-            {testimonial}
+          <Paragraph
+            size="sm"
+            className="peer"
+            // title={testimonial}
+          >
+            <span className="max-w-[32ch] line-clamp-4">{testimonial}</span>
+            <button
+              className="text-fg italic font-[400] inline sm:hidden"
+              onClick={() => setExpandText(true)}
+            >
+              Keep reading...
+            </button>
           </Paragraph>
+          {/* all review text */}
+          <div
+            className={clsx(
+              "absolute inset-0 sm:hidden sm:peer-hover:block sm:peer-hover:animate-slide-from-right hover:block",
+              expandText ? "block animate-slide-from-right" : "hidden"
+            )}
+          >
+            <div className="absolute w-full max-w-[320px] top-0 bottom-0 right-0 bg-bg/10 backdrop-blur-xl opacity-100 rounded-lg p-3 overflow-auto">
+              <Paragraph size="sm" className="">
+                {testimonial}
+              </Paragraph>
+            </div>
+          </div>
         </div>
       </div>
       {/* overlay */}


### PR DESCRIPTION
improve `TestimonialCard` component to support long review text in acceptable look, by implementing truncate and expandable review text.

This improvement insures:
- All card reviews will have display `4 lines` of text maximum.
- Users will have the option to expand text by clicking on `Keep reading...` button in small screens.
- Or by `hovering` over the review text in larger screens (`>=640px `).
- A sliding component displaying all the `review` text will appear for both action.