### PR TITLE
fix: update `Footer` links 

### DIFF
--- a/src/components/base/Footer.tsx
+++ b/src/components/base/Footer.tsx
@@ -33,12 +33,12 @@ const FOOTER_MENU = [
 
 const REPO_LINKS = [
   {
-    item: "how to contribute",
+    item: "github repository",
     href: Settings.githubRepo,
   },
   {
-    item: "github repository",
-    href: Settings.githubRepo,
+    item: "how to contribute",
+    href: `${Settings.githubRepo}/blob/main/CONTRIBUTING.md`,
   },
   {
     item: "opened issues",


### PR DESCRIPTION
- Update the `How to contribute` to link the right page on github


- [x] Code follows project standards
- [x] Tests added/updated for changes
- [x] Documentation updated if needed
- [x] No console.log statements left
- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [x] All tests pass